### PR TITLE
Add required permission for private repo

### DIFF
--- a/content/misc/automerge_dependabot_prs_on_github.md
+++ b/content/misc/automerge_dependabot_prs_on_github.md
@@ -66,6 +66,7 @@ on: pull_request
 
 permissions:
   contents: write
+  pull-requests: write  # Needed if in a private repository
 
 jobs:
   dependabot:


### PR DESCRIPTION
Thanks for a great blog post! I noticed that the permission is slightly different 
for private repos and this is the trial and error that made it work on my end. :) 

Not entirely sure why this works as-is on a public repo and why 
it has to be added for a private, but that's the case. 🤷

I also made this step to approve the PR because my private repos require 
at least one approving review for it to merge. But I wasn't sure about adding it
to the post so I'll just mention it here. :)

```yaml
      - name: Approve the PR
        run: gh pr review --approve "$PR_URL"
        env:
          PR_URL: ${{github.event.pull_request.html_url}}
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```